### PR TITLE
Philiprodrigues/repeat triggers

### DIFF
--- a/plugins/TriggerDecisionEmulator.hpp
+++ b/plugins/TriggerDecisionEmulator.hpp
@@ -85,6 +85,9 @@ private:
   void estimate_current_timestamp();
   void read_inhibit_queue();
 
+  // Create the next trigger decision
+  dfmessages::TriggerDecision create_decision(dfmessages::timestamp_t timestamp);
+  
   // Queue sources and sinks
   std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>> m_time_sync_source;
   std::unique_ptr<appfwk::DAQSource<dfmessages::TriggerInhibit>> m_trigger_inhibit_source;
@@ -119,6 +122,8 @@ private:
   int m_min_links_in_request;
   int m_max_links_in_request;
 
+  int m_repeat_trigger_count{1};
+  
   uint64_t m_clock_frequency_hz;
   
   // The estimate of the current timestamp

--- a/schema/trigemu-TriggerDecisionEmulator-schema.jsonnet
+++ b/schema/trigemu-TriggerDecisionEmulator-schema.jsonnet
@@ -8,33 +8,48 @@ local types = {
   link_count: s.number("link_count", dtype="i4"),
   ticks: s.number("ticks", dtype="i8"),
   freq: s.number("frequency", dtype="u8"),
+  repeat_count: s.number("repeat_count", dtype="i4"),
   
   conf : s.record("ConfParams", [
     s.field("links", self.linkvec,
       doc="List of link identifiers that may be included into trigger decision"),
+
     s.field("min_links_in_request", self.link_count, 10,
       doc="Minimum number of links to include in the trigger decision"),
+
     s.field("max_links_in_request", self.link_count, 10,
       doc="Maximum number of links to include in the trigger decision"),
+
     s.field("min_readout_window_ticks", self.ticks, 3200,
       doc="Minimum readout window to ask data for in 16 ns time ticks (default 51.2 us)"),
+
     s.field("max_readout_window_ticks", self.ticks, 320000,
       doc="Maximum readout window to ask data for in 16 ns time ticks (default 5.12 ms)"),
+
     s.field("trigger_window_offset", self.ticks, 1600,
       doc="Offset of trigger window start time in ticks before trigger timestamp"),
+
     s.field("trigger_interval_ticks", self.ticks, 64000000,
       doc="Interval between triggers in 16 ns time ticks (default 1.024 s) "),
+
     s.field("trigger_offset", self.ticks, 0,
       doc="Trigger timestamp modulo trigger_interval_ticks (default zero)"),
+
     s.field("trigger_delay_ticks", self.ticks, 5000000,
       doc="Number of ticks after timestamp occurs at which to emit trigger decision"),
+
     s.field("clock_frequency_hz", self.ticks, 50000000,
       doc="Assumed clock frequency in Hz (for current-timestamp estimation)"),
+
+    s.field("repeat_trigger_count", self.repeat_count, 1,
+      doc="Number of times to send each trigger decision (for overlapping trigger tests)"),
+
   ], doc="TriggerDecisionEmulator configuration parameters"),
 
   resume: s.record("ResumeParams", [
     s.field("trigger_interval_ticks", self.ticks, 64000000,
       doc="Interval between triggers in 16 ns time ticks (default 1.024 s)"),
+
   ], doc="TriggerDecisionEmulator resume parameters"),
   
 };


### PR DESCRIPTION
Add config parameter to send each trigger decision multiple times. This allows us to test the handling of overlapping trigger requests in the `readout` code