### PR TITLE
Add burst-at-stop functionality to TriggerDecisionEmulator

### DIFF
--- a/plugins/TriggerDecisionEmulator.hpp
+++ b/plugins/TriggerDecisionEmulator.hpp
@@ -118,6 +118,12 @@ private:
 
   uint64_t m_clock_frequency_hz; // NOLINT
 
+  // At stop, send this number of triggers in one go. The idea here is
+  // to put lots of triggers into the system to check that the stop
+  // sequence is clean, in the sense of all the in-flight triggers
+  // getting to disk
+  int m_stop_burst_count{ 0 };
+  
   // The estimate of the current timestamp
   std::atomic<dfmessages::timestamp_t> m_current_timestamp_estimate{ INVALID_TIMESTAMP };
 

--- a/schema/trigemu-TriggerDecisionEmulator-schema.jsonnet
+++ b/schema/trigemu-TriggerDecisionEmulator-schema.jsonnet
@@ -44,6 +44,9 @@ local types = {
     s.field("repeat_trigger_count", self.repeat_count, 1,
       doc="Number of times to send each trigger decision (for overlapping trigger tests)"),
 
+    s.field("stop_burst_count", self.repeat_count, 0,
+      doc="Number of triggers to send ~simultaneously at stop (for queue draining tests)"),
+
   ], doc="TriggerDecisionEmulator configuration parameters"),
 
   resume: s.record("ResumeParams", [


### PR DESCRIPTION
Phil,
Would you be OK with merging the burst-at-stop branch to develop in the trigemu repo?

My sense is that having this functionality available in the main line of development of trigemu will be valuable.

I'm creating the Pull Request as a way to communicate this request to you.  I don't believe that I have write access to the trigemu repo, otherwise I would have merged the newer changes in develop into the phililprodrigues/burst-at-stop branch...