### PR TITLE
Handle stop/start and scrap/conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,12 @@ daq_setup_environment()
 find_package(appfwk REQUIRED)
 find_package(dfmessages REQUIRED)
 
-daq_add_plugin(TriggerDecisionEmulator duneDAQModule LINK_LIBRARIES appfwk::appfwk dfmessages::dfmessages SCHEMA)
+daq_add_library(TimestampEstimator.cpp LINK_LIBRARIES appfwk::appfwk dfmessages::dfmessages)
 
-daq_add_plugin(FakeTimeSyncSource duneDAQModule LINK_LIBRARIES appfwk::appfwk dfmessages::dfmessages SCHEMA)
-daq_add_plugin(FakeInhibitGenerator duneDAQModule LINK_LIBRARIES appfwk::appfwk dfmessages::dfmessages TEST SCHEMA)
-daq_add_plugin(FakeRequestReceiver duneDAQModule LINK_LIBRARIES appfwk::appfwk dfmessages::dfmessages TEST)
+daq_add_plugin(TriggerDecisionEmulator duneDAQModule LINK_LIBRARIES trigemu SCHEMA)
+
+daq_add_plugin(FakeTimeSyncSource duneDAQModule LINK_LIBRARIES trigemu SCHEMA)
+daq_add_plugin(FakeInhibitGenerator duneDAQModule LINK_LIBRARIES trigemu TEST SCHEMA)
+daq_add_plugin(FakeRequestReceiver duneDAQModule LINK_LIBRARIES trigemu TEST)
 
 daq_install()

--- a/include/trigemu/Issues.hpp
+++ b/include/trigemu/Issues.hpp
@@ -1,0 +1,7 @@
+#include "ers/ers.h"
+
+namespace dunedaq {
+ERS_DECLARE_ISSUE(trigemu, InvalidTimeSync, "An invalid TimeSync message was received", ERS_EMPTY)
+
+ERS_DECLARE_ISSUE(trigemu, InvalidConfiguration, "An invalid configuration object was received", ERS_EMPTY)
+} // dunedaq

--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -99,6 +99,8 @@ TriggerDecisionEmulator::do_configure(const nlohmann::json& confobj)
   }
 
   m_configured_flag.store(true);
+  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
+  
   m_estimate_current_timestamp_thread=std::thread(&TriggerDecisionEmulator::estimate_current_timestamp, this);
   pthread_setname_np(m_estimate_current_timestamp_thread.native_handle(), "tde-ts-est");
 }
@@ -107,7 +109,6 @@ void
 TriggerDecisionEmulator::do_start(const nlohmann::json& startobj)
 {
   m_run_number = startobj.value<dunedaq::dataformats::run_number_t>("run", 0);
-  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
 
   m_paused.store(true);
   m_running_flag.store(true);

--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -9,6 +9,7 @@
 
 #include "TriggerDecisionEmulator.hpp"
 
+
 #include "dataformats/ComponentRequest.hpp"
 
 #include "dfmessages/TimeSync.hpp"
@@ -17,6 +18,8 @@
 #include "dfmessages/Types.hpp"
 #include "ers/ers.h"
 
+#include "trigemu/Issues.hpp"
+#include "trigemu/TimestampEstimator.hpp"
 #include "trigemu/triggerdecisionemulator/Nljs.hpp"
 #include "trigemu/triggerdecisionemulator/Structs.hpp"
 
@@ -47,6 +50,7 @@ TriggerDecisionEmulator::TriggerDecisionEmulator(const std::string& name)
   register_command("pause", &TriggerDecisionEmulator::do_pause);
   register_command("resume", &TriggerDecisionEmulator::do_resume);
   register_command("scrap", &TriggerDecisionEmulator::do_scrap);
+
 }
 
 void
@@ -97,12 +101,6 @@ TriggerDecisionEmulator::do_configure(const nlohmann::json& confobj)
   if (m_min_readout_window_ticks > m_max_readout_window_ticks || m_min_links_in_request > m_max_links_in_request) {
     throw InvalidConfiguration(ERS_HERE);
   }
-
-  m_configured_flag.store(true);
-  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
-  
-  m_estimate_current_timestamp_thread=std::thread(&TriggerDecisionEmulator::estimate_current_timestamp, this);
-  pthread_setname_np(m_estimate_current_timestamp_thread.native_handle(), "tde-ts-est");
 }
 
 void
@@ -111,11 +109,14 @@ TriggerDecisionEmulator::do_start(const nlohmann::json& startobj)
   m_run_number = startobj.value<dunedaq::dataformats::run_number_t>("run", 0);
 
   m_paused.store(true);
+  m_inhibited.store(false);
   m_running_flag.store(true);
 
-
+  m_timestamp_estimator.reset(new TimestampEstimator(m_time_sync_source, m_clock_frequency_hz));
+  
   m_read_inhibit_queue_thread=std::thread(&TriggerDecisionEmulator::read_inhibit_queue, this);
   pthread_setname_np(m_read_inhibit_queue_thread.native_handle(), "tde-inhibit-q");
+
   m_send_trigger_decisions_thread=std::thread(&TriggerDecisionEmulator::send_trigger_decisions, this);
   pthread_setname_np(m_send_trigger_decisions_thread.native_handle(), "tde-trig-dec");
 }
@@ -124,6 +125,7 @@ void
 TriggerDecisionEmulator::do_stop(const nlohmann::json& /*stopobj*/)
 {
   m_running_flag.store(false);
+  m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimator dtor
   m_read_inhibit_queue_thread.join();
   m_send_trigger_decisions_thread.join();
 }
@@ -148,8 +150,6 @@ TriggerDecisionEmulator::do_resume(const nlohmann::json& resumeobj)
 void
 TriggerDecisionEmulator::do_scrap(const nlohmann::json& /*stopobj*/)
 {
-  m_configured_flag.store(false);
-  m_estimate_current_timestamp_thread.join();
 }
 
 dfmessages::TriggerDecision
@@ -192,11 +192,11 @@ TriggerDecisionEmulator::send_trigger_decisions()
   m_last_trigger_number=0;
 
   // Wait for there to be a valid timestamp estimate before we start
-  while (m_running_flag.load() && m_current_timestamp_estimate.load() == INVALID_TIMESTAMP) {
+  while (m_running_flag.load() && m_timestamp_estimator->get_timestamp_estimate() == INVALID_TIMESTAMP) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
-  dfmessages::timestamp_t ts = m_current_timestamp_estimate.load();
+  dfmessages::timestamp_t ts = m_timestamp_estimator->get_timestamp_estimate();
   ERS_DEBUG(1, "Delaying trigger decision sending by " << trigger_delay_ticks_ << " ticks");
   // Round up to the next multiple of trigger_interval_ticks_
   dfmessages::timestamp_t next_trigger_timestamp =
@@ -207,8 +207,8 @@ TriggerDecisionEmulator::send_trigger_decisions()
 
   while (true) {
     while (m_running_flag.load() &&
-           (m_current_timestamp_estimate.load() < (next_trigger_timestamp + trigger_delay_ticks_) ||
-            m_current_timestamp_estimate.load() == INVALID_TIMESTAMP)) {
+           (m_timestamp_estimator->get_timestamp_estimate() < (next_trigger_timestamp + trigger_delay_ticks_) ||
+            m_timestamp_estimator->get_timestamp_estimate() == INVALID_TIMESTAMP)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     if (!m_running_flag.load())
@@ -220,7 +220,7 @@ TriggerDecisionEmulator::send_trigger_decisions()
 
       for (int i = 0; i < m_repeat_trigger_count; ++i) {
         ERS_DEBUG(0,
-                  "At timestamp " << m_current_timestamp_estimate.load() << ", pushing a decision with triggernumber "
+                  "At timestamp " << m_timestamp_estimator->get_timestamp_estimate() << ", pushing a decision with triggernumber "
                                   << decision.m_trigger_number << " timestamp " << decision.m_trigger_timestamp
                                   << " number of links " << decision.m_components.size());
         m_trigger_decision_sink->push(decision, std::chrono::milliseconds(10));
@@ -253,68 +253,27 @@ TriggerDecisionEmulator::send_trigger_decisions()
 
 }
 
-void
-TriggerDecisionEmulator::estimate_current_timestamp()
-{
-  dfmessages::TimeSync most_recent_timesync{ INVALID_TIMESTAMP };
-  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
-
-  int i = 0;
-
-  // time_sync_source_ is connected to an MPMC queue with multiple
-  // writers. We read whatever we can off it, and the item with the
-  // largest timestamp "wins"
-  while (m_configured_flag.load()) {
-    // First, update the latest timestamp
-    while (m_time_sync_source->can_pop()) {
-      dfmessages::TimeSync t{ INVALID_TIMESTAMP };
-      m_time_sync_source->pop(t);
-      dfmessages::timestamp_t estimate = m_current_timestamp_estimate.load();
-      dfmessages::timestamp_diff_t diff = estimate - t.m_daq_time;
-      ERS_DEBUG(10,
-                "Got a TimeSync timestamp = " << t.m_daq_time << ", system time = " << t.m_system_time
-                                              << " when current timestamp estimate was " << estimate
-                                              << ". diff=" << diff);
-      if (most_recent_timesync.m_daq_time == INVALID_TIMESTAMP || t.m_daq_time > most_recent_timesync.m_daq_time) {
-        most_recent_timesync = t;
-      }
-    }
-
-    if (most_recent_timesync.m_daq_time != INVALID_TIMESTAMP) {
-      // Update the current timestamp estimate, based on the most recently-read TimeSync
-      using namespace std::chrono;
-      // std::chrono is the worst
-      auto time_now =
-        static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
-      if (time_now < most_recent_timesync.m_system_time) {
-        ers::error(InvalidTimeSync(ERS_HERE));
-      } else {
-        auto delta_time = time_now - most_recent_timesync.m_system_time;
-        const dfmessages::timestamp_t new_timestamp =
-          most_recent_timesync.m_daq_time + delta_time * m_clock_frequency_hz / 1000000;
-        if (i++ % 100 == 0) { // NOLINT
-          ERS_DEBUG(1, "Updating timestamp estimate to " << new_timestamp);
-        }
-        m_current_timestamp_estimate.store(new_timestamp);
-      }
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
-
-  // We get here after the "scrap" command is issued, at which point
-  // we should drain the input queue, so the TimeSyncs on it don't
-  // turn up in the next run. We're not going to do anything with
-  // them, so we just drop them on the floor
-  while (m_time_sync_source->can_pop()) {
-    dfmessages::TimeSync t{ INVALID_TIMESTAMP };
-    m_time_sync_source->pop(t);
-  }
-}
 
 void
 TriggerDecisionEmulator::read_inhibit_queue()
 {
+  // This loop is a hack to deal with the fact that there might be
+  // leftover TriggerInhibit messages from the previous run, because
+  // TriggerDecisionEmulator is stopped before the DF modules that
+  // send the TriggerInhibits. So we pop everything we can at
+  // startup. This will definitely get all of the TriggerInhibits from
+  // the previous run. It *may* also get TriggerInhibits from the
+  // current run, which we drop on the floor. This is not really
+  // ideal, since we don't know whether a given message on the queue
+  // came from the previous (and should be ignored) or from this run
+  // (and should be handled). The problem would be when an inhibit is
+  // sent in this run before this loop gets started. That seems
+  // unlikely, and the whole way we do inhibits is changing for
+  // MiniDAQApp v2 anyway, so I'm leaving it like this
+  while (m_trigger_inhibit_source->can_pop()) {
+    dfmessages::TriggerInhibit ti;
+    m_trigger_inhibit_source->pop(ti);
+  }
   while (m_running_flag.load()) {
     while (m_trigger_inhibit_source->can_pop()) {
       dfmessages::TriggerInhibit ti;

--- a/plugins/TriggerDecisionEmulator.hpp
+++ b/plugins/TriggerDecisionEmulator.hpp
@@ -14,6 +14,8 @@
 #ifndef TRIGEMU_PLUGINS_TRIGGERDECISIONEMULATOR_HPP_
 #define TRIGEMU_PLUGINS_TRIGGERDECISIONEMULATOR_HPP_
 
+#include "trigemu/TimestampEstimator.hpp"
+
 #include "dataformats/GeoID.hpp"
 #include "dfmessages/TimeSync.hpp"
 #include "dfmessages/TriggerDecision.hpp"
@@ -24,17 +26,11 @@
 #include "appfwk/DAQSink.hpp"
 #include "appfwk/DAQSource.hpp"
 
-#include <ers/ers.h>
-
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace dunedaq {
-
-ERS_DECLARE_ISSUE(trigemu, InvalidTimeSync, "An invalid TimeSync message was received", ERS_EMPTY)
-
-ERS_DECLARE_ISSUE(trigemu, InvalidConfiguration, "An invalid configuration object was received", ERS_EMPTY)
 
 namespace trigemu {
 
@@ -75,14 +71,16 @@ private:
 
   // Thread functions
   void send_trigger_decisions();
-  void estimate_current_timestamp();
+  // void estimate_current_timestamp();
   void read_inhibit_queue();
 
   // ...and the std::threads that hold them
   std::thread m_send_trigger_decisions_thread;
-  std::thread m_estimate_current_timestamp_thread;
+  // std::thread m_estimate_current_timestamp_thread;
   std::thread m_read_inhibit_queue_thread;
 
+  std::unique_ptr<TimestampEstimator> m_timestamp_estimator;
+  
   // Create the next trigger decision
   dfmessages::TriggerDecision create_decision(dfmessages::timestamp_t timestamp);
 
@@ -130,8 +128,6 @@ private:
   // getting to disk
   int m_stop_burst_count{ 0 };
 
-  // The estimate of the current timestamp
-  std::atomic<dfmessages::timestamp_t> m_current_timestamp_estimate{ INVALID_TIMESTAMP };
 
   // The most recent inhibit status we've seen (true = inhibited)
   std::atomic<bool> m_inhibited;
@@ -145,8 +141,6 @@ private:
 
   // Are we in the RUNNING state?
   std::atomic<bool> m_running_flag{false};
-  // Are we in a configured state, ie after conf and before scrap?
-  std::atomic<bool> m_configured_flag{false};
 };
 } // namespace trigemu
 } // namespace dunedaq

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -1,0 +1,91 @@
+#include "trigemu/TimestampEstimator.hpp"
+#include "trigemu/Issues.hpp"
+
+namespace dunedaq::trigemu {
+
+TimestampEstimator::TimestampEstimator(std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>>& time_sync_source,
+                                         uint64_t clock_frequency_hz)
+  : m_running_flag(true)
+  , m_clock_frequency_hz(clock_frequency_hz)
+  , m_estimator_thread(&TimestampEstimator::estimator_thread_fn, this, std::ref(time_sync_source))
+{
+  pthread_setname_np(m_estimator_thread.native_handle(), "tde-ts-est");
+}
+
+TimestampEstimator::~TimestampEstimator()
+{
+  m_running_flag.store(false);
+  m_estimator_thread.join();
+}
+  
+void TimestampEstimator::estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>>& time_sync_source)
+{
+  // This loop is a hack to deal with the fact that there might be
+  // leftover TimeSync messages from the previous run, because
+  // TriggerDecisionEmulator is stopped before the readout modules
+  // that send the TimeSyncs. So we pop everything we can at
+  // startup. This will definitely get all of the TimeSyncs from the
+  // previous run. It *may* also get TimeSyncs from the current run,
+  // which we drop on the floor. This is fairly harmless: it'll just
+  // slightly delay us getting to the point where we actually start
+  // making the timestamp estimate
+  while (time_sync_source->can_pop()) {
+    dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+    time_sync_source->pop(t);
+  }
+  
+  dfmessages::TimeSync most_recent_timesync{ INVALID_TIMESTAMP };
+  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
+
+  int i = 0;
+
+  // time_sync_source_ is connected to an MPMC queue with multiple
+  // writers. We read whatever we can off it, and the item with the
+  // largest timestamp "wins"
+  while (m_running_flag.load()) {
+    // First, update the latest timestamp
+    while (time_sync_source->can_pop()) {
+      dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+      time_sync_source->pop(t);
+      dfmessages::timestamp_t estimate = m_current_timestamp_estimate.load();
+      dfmessages::timestamp_diff_t diff = estimate - t.m_daq_time;
+      ERS_DEBUG(10,
+                "Got a TimeSync timestamp = " << t.m_daq_time << ", system time = " << t.m_system_time
+                << " when current timestamp estimate was " << estimate
+                << ". diff=" << diff);
+      if (most_recent_timesync.m_daq_time == INVALID_TIMESTAMP || t.m_daq_time > most_recent_timesync.m_daq_time) {
+        most_recent_timesync = t;
+      }
+    }
+
+    if (most_recent_timesync.m_daq_time != INVALID_TIMESTAMP) {
+      // Update the current timestamp estimate, based on the most recently-read TimeSync
+      using namespace std::chrono;
+      // std::chrono is the worst
+      auto time_now =
+        static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+      if (time_now < most_recent_timesync.m_system_time) {
+        // ers::error(InvalidTimeSync(ERS_HERE));
+      } else {
+        auto delta_time = time_now - most_recent_timesync.m_system_time;
+        const dfmessages::timestamp_t new_timestamp =
+          most_recent_timesync.m_daq_time + delta_time * m_clock_frequency_hz / 1000000;
+        if (i++ % 100 == 0) { // NOLINT
+          ERS_DEBUG(1, "Updating timestamp estimate to " << new_timestamp);
+        }
+        m_current_timestamp_estimate.store(new_timestamp);
+      }
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Drain the input queue as best we can. We're not going to do
+  // anything with the TimeSync messages, so we just drop them on the
+  // floor
+  while (time_sync_source->can_pop()) {
+    dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+    time_sync_source->pop(t);
+  }
+}
+} // dunedaq::trigemu

--- a/src/trigemu/TimestampEstimator.hpp
+++ b/src/trigemu/TimestampEstimator.hpp
@@ -1,0 +1,48 @@
+/**
+ * @file TimestampEstimator.hpp TimestampEstimator Class
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGEMU_SRC_TRIGEMU_TIMESTAMPESTIMATOR_HPP_
+#define TRIGEMU_SRC_TRIGEMU_TIMESTAMPESTIMATOR_HPP_
+
+#include "appfwk/DAQSource.hpp"
+
+#include "dfmessages/Types.hpp"
+#include "dfmessages/TimeSync.hpp"
+
+#include <atomic>
+#include <thread>
+
+namespace dunedaq {
+namespace trigemu {
+
+class TimestampEstimator
+{
+public:
+  TimestampEstimator(std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>>& time_sync_source,
+                     uint64_t clock_frequency_hz);
+
+  ~TimestampEstimator();
+  
+  dfmessages::timestamp_t get_timestamp_estimate() const { return m_current_timestamp_estimate.load(); }
+private:
+  void estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>>& time_sync_source);
+
+  static constexpr dfmessages::timestamp_t INVALID_TIMESTAMP = 0xffffffffffffffff;
+  
+  // The estimate of the current timestamp
+  std::atomic<dfmessages::timestamp_t> m_current_timestamp_estimate{ INVALID_TIMESTAMP };
+
+  std::atomic<bool> m_running_flag{false};
+  uint64_t m_clock_frequency_hz; // NOLINT
+  std::thread m_estimator_thread;
+};
+  
+} // namespace trigemu
+} // namespace dunedaq
+
+#endif // TRIGEMU_SRC_TRIGEMU_TIMESTAMPESTIMATOR_HPP_


### PR DESCRIPTION
This PR has changes to correctly handle stop-then-start and scrap-then-conf. The timestamp estimation (based on reading TimeSync messages) now runs from "conf" to "scrap", instead of from "start" to "stop".

I tested with the `bugfix/StopStartFilePtr` branch of `dfmodules` and the `glm/stopstart` branch of `readout`, with which I can issue stop then start, and scrap then conf, and successfully see triggers making it to the `DataWriter`