### PR TITLE
Fix the case where no TimeSyncs are received at all between "start" and "stop"

### DIFF
--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -146,10 +146,12 @@ void
 TriggerDecisionEmulator::do_stop(const nlohmann::json& /*stopobj*/)
 {
   m_running_flag.store(false);
-  m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimator dtor
+
   m_read_inhibit_queue_thread.join();
   m_read_token_queue_thread.join();
   m_send_trigger_decisions_thread.join();
+
+  m_timestamp_estimator.reset(nullptr); // Calls TimestampEstimator dtor
 }
 
 void
@@ -221,7 +223,13 @@ TriggerDecisionEmulator::send_trigger_decisions()
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
+  if (!m_running_flag.load()) {
+    // We get here if we were stopped before the TimestampEstimator received any TimeSyncs
+    return;
+  }
+
   dfmessages::timestamp_t ts = m_timestamp_estimator->get_timestamp_estimate();
+
   TLOG_DEBUG(1) << "Delaying trigger decision sending by " << trigger_delay_ticks_ << " ticks";
   // Round up to the next multiple of trigger_interval_ticks_
   dfmessages::timestamp_t next_trigger_timestamp =


### PR DESCRIPTION
There were two separate problems:

1. The m_timestamp_estimator pointer was reset (calling TimestampEstimator's dtor)  _before_ joining the threads at stop, so threads could dereference a nullptr
2. The case where the wait for a valid timestamp at the start of send_trigger_decisions was interrupted by stop was not handled correctly. We should just return there, not carry on as if a valid timestamp was available

To reproduce the problem, create a two-process minidaqapp config, run just the trigemu process, and send it "init", "conf", "start", "stop". Eg:

```
python rudf_trg.py
daq_application --name trigemu -c stdin://minidaqapp-trgemu.json
```

Without this PR, I get a segfault