### PR TITLE
Add "initial_token_count" parameter to TriggerDecisionEmulator, for

### DIFF
--- a/plugins/TriggerDecisionEmulator.hpp
+++ b/plugins/TriggerDecisionEmulator.hpp
@@ -95,8 +95,6 @@ private:
   std::unique_ptr<appfwk::DAQSource<dfmessages::TriggerDecisionToken>> m_token_source;
   std::unique_ptr<appfwk::DAQSink<dfmessages::TriggerDecision>> m_trigger_decision_sink;
 
-  static constexpr dfmessages::timestamp_t INVALID_TIMESTAMP = 0xffffffffffffffff;
-
   // Variables controlling how we produce triggers
 
   // Triggers are produced for timestamps:
@@ -137,6 +135,7 @@ private:
   // The most recent inhibit status we've seen (true = inhibited)
   std::atomic<bool> m_inhibited;
   std::atomic<int> m_tokens;
+  int m_initial_tokens;
   std::mutex m_open_trigger_decisions_mutex;
   std::set<dfmessages::trigger_number_t> m_open_trigger_decisions;
   // paused state, equivalent to inhibited

--- a/schema/trigemu/triggerdecisionemulator.jsonnet
+++ b/schema/trigemu/triggerdecisionemulator.jsonnet
@@ -9,6 +9,7 @@ local types = {
   ticks: s.number("ticks", dtype="i8"),
   freq: s.number("frequency", dtype="u8"),
   repeat_count: s.number("repeat_count", dtype="i4"),
+  token_count: s.number("token_count", dtype="i4"),
   
   conf : s.record("ConfParams", [
     s.field("links", self.linkvec,
@@ -43,9 +44,13 @@ local types = {
 
     s.field("repeat_trigger_count", self.repeat_count, 1,
       doc="Number of times to send each trigger decision (for overlapping trigger tests)"),
-
+      
     s.field("stop_burst_count", self.repeat_count, 0,
       doc="Number of triggers to send ~simultaneously at stop (for queue draining tests)"),
+
+    s.field("initial_token_count", self.token_count, 0,
+      doc="Number of trigger tokens to start the run with"),
+
 
   ], doc="TriggerDecisionEmulator configuration parameters"),
 

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -35,12 +35,12 @@ TimestampEstimator::estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmess
   // slightly delay us getting to the point where we actually start
   // making the timestamp estimate
   while (time_sync_source->can_pop()) {
-    dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+    dfmessages::TimeSync t{ dfmessages::TypeDefaults::s_invalid_timestamp };
     time_sync_source->pop(t);
   }
 
-  dfmessages::TimeSync most_recent_timesync{ INVALID_TIMESTAMP };
-  m_current_timestamp_estimate.store(INVALID_TIMESTAMP);
+  dfmessages::TimeSync most_recent_timesync{ dfmessages::TypeDefaults::s_invalid_timestamp };
+  m_current_timestamp_estimate.store(dfmessages::TypeDefaults::s_invalid_timestamp);
 
   int i = 0;
 
@@ -50,18 +50,19 @@ TimestampEstimator::estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmess
   while (m_running_flag.load()) {
     // First, update the latest timestamp
     while (time_sync_source->can_pop()) {
-      dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+      dfmessages::TimeSync t{ dfmessages::TypeDefaults::s_invalid_timestamp };
       time_sync_source->pop(t);
       dfmessages::timestamp_t estimate = m_current_timestamp_estimate.load();
       dfmessages::timestamp_diff_t diff = estimate - t.daq_time;
       TLOG_DEBUG(10) << "Got a TimeSync timestamp = " << t.daq_time << ", system time = " << t.system_time
                      << " when current timestamp estimate was " << estimate << ". diff=" << diff;
-      if (most_recent_timesync.daq_time == INVALID_TIMESTAMP || t.daq_time > most_recent_timesync.daq_time) {
+      if (most_recent_timesync.daq_time == dfmessages::TypeDefaults::s_invalid_timestamp ||
+          t.daq_time > most_recent_timesync.daq_time) {
         most_recent_timesync = t;
       }
     }
 
-    if (most_recent_timesync.daq_time != INVALID_TIMESTAMP) {
+    if (most_recent_timesync.daq_time != dfmessages::TypeDefaults::s_invalid_timestamp) {
       // Update the current timestamp estimate, based on the most recently-read TimeSync
       using namespace std::chrono;
       // std::chrono is the worst
@@ -87,7 +88,7 @@ TimestampEstimator::estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmess
   // anything with the TimeSync messages, so we just drop them on the
   // floor
   while (time_sync_source->can_pop()) {
-    dfmessages::TimeSync t{ INVALID_TIMESTAMP };
+    dfmessages::TimeSync t{ dfmessages::TypeDefaults::s_invalid_timestamp };
     time_sync_source->pop(t);
   }
 }

--- a/src/trigemu/TimestampEstimator.hpp
+++ b/src/trigemu/TimestampEstimator.hpp
@@ -33,10 +33,8 @@ public:
 private:
   void estimator_thread_fn(std::unique_ptr<appfwk::DAQSource<dfmessages::TimeSync>>& time_sync_source);
 
-  static constexpr dfmessages::timestamp_t INVALID_TIMESTAMP = 0xffffffffffffffff;
-
   // The estimate of the current timestamp
-  std::atomic<dfmessages::timestamp_t> m_current_timestamp_estimate{ INVALID_TIMESTAMP };
+  std::atomic<dfmessages::timestamp_t> m_current_timestamp_estimate{ dfmessages::TypeDefaults::s_invalid_timestamp };
 
   std::atomic<bool> m_running_flag{ false };
   uint64_t m_clock_frequency_hz; // NOLINT


### PR DESCRIPTION
credit-based TriggerDecisionToken tracking. Resolves #23 (with configuration changes in `minidaqapp`)