### PR TITLE
Better handling of invalid `trigger_interval_ticks`

### DIFF
--- a/include/trigemu/Issues.hpp
+++ b/include/trigemu/Issues.hpp
@@ -4,4 +4,6 @@ namespace dunedaq {
 ERS_DECLARE_ISSUE(trigemu, InvalidTimeSync, "An invalid TimeSync message was received", ERS_EMPTY)
 
 ERS_DECLARE_ISSUE(trigemu, InvalidConfiguration, "An invalid configuration object was received", ERS_EMPTY)
+
+ERS_DECLARE_ISSUE(trigemu, InvalidTriggerInterval, "An invalid trigger interval of " << interval << " was requested", ((uint64_t)interval))
 } // dunedaq

--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -169,8 +169,7 @@ TriggerDecisionEmulator::do_resume(const nlohmann::json& resumeobj)
 {
   auto params = resumeobj.get<triggerdecisionemulator::ResumeParams>();
   if(params.trigger_interval_ticks<=0){
-    ers::fatal(InvalidTriggerInterval(ERS_HERE, params.trigger_interval_ticks));
-    return;
+    throw InvalidTriggerInterval(ERS_HERE, params.trigger_interval_ticks);
   }
   m_trigger_interval_ticks.store(params.trigger_interval_ticks);
 

--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -23,6 +23,7 @@
 #include "trigemu/triggerdecisionemulatorinfo/Nljs.hpp"
 
 #include "appfwk/app/Nljs.hpp"
+#include "rcif/cmd/Nljs.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -124,7 +125,12 @@ TriggerDecisionEmulator::do_configure(const nlohmann::json& confobj)
 void
 TriggerDecisionEmulator::do_start(const nlohmann::json& startobj)
 {
-  m_run_number = startobj.value<dunedaq::dataformats::run_number_t>("run", 0);
+  auto start_pars=startobj.get<dunedaq::rcif::cmd::StartParams>();
+  m_run_number = start_pars.run;
+
+  if(start_pars.trigger_interval_ticks<=0){
+    throw InvalidTriggerInterval(ERS_HERE, start_pars.trigger_interval_ticks);
+  }
 
   m_paused.store(true);
   m_inhibited.store(false);

--- a/plugins/TriggerDecisionEmulator.cpp
+++ b/plugins/TriggerDecisionEmulator.cpp
@@ -168,6 +168,10 @@ void
 TriggerDecisionEmulator::do_resume(const nlohmann::json& resumeobj)
 {
   auto params = resumeobj.get<triggerdecisionemulator::ResumeParams>();
+  if(params.trigger_interval_ticks<=0){
+    ers::fatal(InvalidTriggerInterval(ERS_HERE, params.trigger_interval_ticks));
+    return;
+  }
   m_trigger_interval_ticks.store(params.trigger_interval_ticks);
 
   TLOG() << "******* Triggers RESUMED! *********";
@@ -235,6 +239,9 @@ TriggerDecisionEmulator::send_trigger_decisions()
   }
 
   dfmessages::timestamp_t ts = m_timestamp_estimator->get_timestamp_estimate();
+
+  // This case should have been caught in do_resume()
+  assert(m_trigger_interval_ticks.load() != 0);
 
   TLOG_DEBUG(1) << "Delaying trigger decision sending by " << trigger_delay_ticks_ << " ticks";
   // Round up to the next multiple of trigger_interval_ticks_

--- a/schema/trigemu/triggerdecisionemulator.jsonnet
+++ b/schema/trigemu/triggerdecisionemulator.jsonnet
@@ -1,12 +1,14 @@
 local moo = import "moo.jsonnet";
 local ns = "dunedaq.trigemu.triggerdecisionemulator";
 local s = moo.oschema.schema(ns);
+local nc = moo.oschema.numeric_constraints;
 
 local types = {
   linkid: s.number("link_id", dtype="i4"),
   linkvec : s.sequence("link_vec", self.linkid),
   link_count: s.number("link_count", dtype="i4"),
   ticks: s.number("ticks", dtype="i8"),
+  trigger_interval: s.number("trigger_interval", dtype="i8", constraints=nc(minimum=1)),
   freq: s.number("frequency", dtype="u8"),
   repeat_count: s.number("repeat_count", dtype="i4"),
   token_count: s.number("token_count", dtype="i4"),
@@ -30,7 +32,7 @@ local types = {
     s.field("trigger_window_offset", self.ticks, 1600,
       doc="Offset of trigger window start time in ticks before trigger timestamp"),
 
-    s.field("trigger_interval_ticks", self.ticks, 64000000,
+    s.field("trigger_interval_ticks", self.trigger_interval, 64000000,
       doc="Interval between triggers in 16 ns time ticks (default 1.024 s) "),
 
     s.field("trigger_offset", self.ticks, 0,
@@ -55,7 +57,7 @@ local types = {
   ], doc="TriggerDecisionEmulator configuration parameters"),
 
   resume: s.record("ResumeParams", [
-    s.field("trigger_interval_ticks", self.ticks, 64000000,
+    s.field("trigger_interval_ticks", self.trigger_interval, 64000000,
       doc="Interval between triggers in 16 ns time ticks (default 1.024 s)"),
 
   ], doc="TriggerDecisionEmulator resume parameters"),


### PR DESCRIPTION
This PR adds better handling for invalid values of `trigger_interval_ticks`, in particular zero. In the moo schema, the `trigger_interval_ticks` value in constrained to be at least 1. Unfortunately, moo currently doesn't do numeric constraints validation when generating from python objects, so this has no effect (yet).

In the `TriggerDecisionEmulator` class itself, the value of `trigger_interval_ticks` is checked in `do_start` and `do_resume`, with an exception thrown if it's zero